### PR TITLE
Up the quality of the jpg to match colours with other file types

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -45,7 +45,7 @@ func getImageWriter(p string) imageWriter {
 		}
 	case ".jpg", ".jpeg":
 		return func(w io.Writer, i image.Image) error {
-			return jpeg.Encode(w, i, &jpeg.Options{Quality: 1})
+			return jpeg.Encode(w, i, &jpeg.Options{Quality: 100})
 		}
 	case "", ".png":
 		return func(w io.Writer, i image.Image) error {


### PR DESCRIPTION
This PR fixes #11 the previous quality of the jpg I believe for the file size purposes was `1` this has been updated to `100` (max value) and it seems to be a similar colour now.

<table>
<thead>
<tr>
<th>PNG</th>
<th>NEW JPG</th>
<th>OLD JPG</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/6791758/62649649-22dc6400-b94d-11e9-8f85-dcb15232fd91.png"/>
</td>
<td>
<img src="https://user-images.githubusercontent.com/6791758/62649699-37b8f780-b94d-11e9-9f49-91551acda29d.jpg"/>
</td>
<td>
<img src="https://user-images.githubusercontent.com/6791758/62649690-31c31680-b94d-11e9-82f8-6f0a41e0545a.jpg"/>
</td>
</tr>
<tr>
<td>
33383 bytes
</td>
<td>
5194 bytes
</td>
<td>
4722 bytes
</td>
</tr>
</tbody>
</table>